### PR TITLE
Fix ODBC driver callbacks signatures

### DIFF
--- a/project/driver/src/NotImplemented.cpp
+++ b/project/driver/src/NotImplemented.cpp
@@ -22,12 +22,14 @@ using odbcrets::EzLoggerPtr;
 
 SQLRETURN SQL_API SQLBindParameter(SQLHSTMT StatementHandle,
                                    SQLUSMALLINT ParameterNumber,
+                                   SQLSMALLINT InputOutputType,
                                    SQLSMALLINT ValueType,
                                    SQLSMALLINT ParameterType,
-                                   SQLULEN LengthPrecision,
-                                   SQLSMALLINT ParameterScale,
-                                   SQLPOINTER ParameterValue,
-                                   SQLLEN *StrLen_or_Ind)
+                                   SQLULEN ColumnSize,
+                                   SQLSMALLINT DecimalDigits,
+                                   SQLPOINTER ParameterValuePtr,
+                                   SQLLEN BufferLength,
+                                   SQLLEN *StrLen_or_IndPtr)
 {
     AbstractHandle* stmt = static_cast<AbstractHandle*>(StatementHandle);
 
@@ -153,6 +155,20 @@ SQLRETURN SQL_API SQLForeignKeys(
     {
         LOG_DEBUG(stmt->getLogger(), "In SQLForeignKeys");
         stmt->addError("HY000", "SQLForeignKeys not implemented.");
+    }
+
+    return SQL_ERROR;
+}
+
+SQLRETURN SQL_API SQLGetConnectOption(SQLHDBC ConnectionHandle,
+                                      SQLUSMALLINT Option, SQLPOINTER Value)
+{
+    AbstractHandle* dbc = static_cast<AbstractHandle*>(ConnectionHandle);
+
+    if (dbc)
+    {
+        LOG_DEBUG(dbc->getLogger(), "In SQLGetConnectOption");
+        dbc->addError("HY000", "SQLGetConnectOption not implemented");
     }
 
     return SQL_ERROR;

--- a/project/driver/src/StmtEntries.cpp
+++ b/project/driver/src/StmtEntries.cpp
@@ -300,7 +300,7 @@ class SQLSetStmtOption : public StmtOdbcEntry
 {
   public:
     SQLSetStmtOption(SQLHSTMT StatementHandle, SQLUSMALLINT Option,
-                     SQLLEN Value)
+                     SQLULEN Value)
         : StmtOdbcEntry(StatementHandle), mOption(Option), mValue(Value) { }
 
   protected:
@@ -311,7 +311,7 @@ class SQLSetStmtOption : public StmtOdbcEntry
 
   private:
     SQLUSMALLINT mOption;
-    SQLLEN mValue;
+    SQLULEN mValue;
 };
 
 class SQLSetStmtAttr : public StmtOdbcEntry
@@ -694,7 +694,7 @@ SQLRETURN SQL_API SQLTables(SQLHSTMT StatementHandle,
 }
 
 SQLRETURN SQL_API SQLSetStmtOption(SQLHSTMT StatementHandle,
-                                   SQLUSMALLINT Option, SQLLEN Value)
+                                   SQLUSMALLINT Option, SQLULEN Value)
 {
     o::SQLSetStmtOption sqlSetStmtOption(StatementHandle, Option, Value);
     return sqlSetStmtOption();
@@ -713,7 +713,12 @@ SQLRETURN SQL_API SQLColAttribute(
     SQLHSTMT StatementHandle, SQLUSMALLINT ColumnNumber,
     SQLUSMALLINT FieldIdentifier, SQLPOINTER CharacterAttribute,
     SQLSMALLINT BufferLength, SQLSMALLINT *StringLength,
-    SQLPOINTER NumericAttribute)
+#ifdef _WIN64
+    SQLLEN *NumericAttribute
+#else
+    SQLPOINTER NumericAttribute
+#endif
+)
 {
     o::SQLColAttribute sqlColAttribute(
         StatementHandle, ColumnNumber, FieldIdentifier, CharacterAttribute,


### PR DESCRIPTION
- Fix SQLBindParameter signature
- Fix SQLSetStmtOption signature
- Fix SQLColAttribute signature on WIN64
- Implement missing SQLGetConnectOption

Wrong signatures lead to ODBC driver callbacks to have C++ linkage/mangling as they do not match extern "C" declarations in sql.h/sqlext.h.
This causes these functions (as they are defined in ezrets.def) on win32 to point to odbc32.dll entry points (so that for example SQLBindParameter in the driver points to the SQLBindParameter from odbc32.dll and so on).

Probably more proper fix is to explicitly have ODBC driver callbacks to have explicit extern "C" linkage.